### PR TITLE
Introduce shx to make pempa installable on Windows

### DIFF
--- a/apps/02-pempa/package.json
+++ b/apps/02-pempa/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"type": "module",
 	"scripts": {
-		"postinstall": "cp ./node_modules/jquery/dist/jquery.min.js ./public/jquery.min.js",
+		"postinstall": "shx cp ./node_modules/jquery/dist/jquery.min.js ./public/jquery.min.js",
 		"start": "node server.js",
 		"dev": "nodemon server.js",
 		"test": "echo \"Error: no test specified\" && exit 1"
@@ -20,5 +20,8 @@
 		"nodemon": "^2.0.20",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
+	},
+	"devDependencies": {
+		"shx": "^0.3.4"
 	}
 }


### PR DESCRIPTION
Should solve this https://github.com/kentcdodds/the-webs-next-transition/issues/2

Is it an overkill to install whole package for one `cp` command? Maybe.
Is it better to write a script solely for that purpose and distract users from real code? Not sure.